### PR TITLE
Don't resize the root view if the height is less than 1.

### DIFF
--- a/d2l-hierarchical-view-behavior.js
+++ b/d2l-hierarchical-view-behavior.js
@@ -345,7 +345,10 @@ D2L.PolymerBehaviors.HierarchicalViewBehavior = {
 		}
 		var content = this.$$('.d2l-hierarchical-view-content');
 		fastdom.measure(function() {
-			this.fire('d2l-hierarchical-view-resize', content.getBoundingClientRect());
+			var contentRect = content.getBoundingClientRect();
+			// don't resize the root view if it's not displayed
+			if (contentRect.height < 1) return;
+			this.fire('d2l-hierarchical-view-resize', contentRect);
 		}.bind(this));
 	},
 


### PR DESCRIPTION
If the content height is less than 1, then the view is likely not displayed.  Don't resize the outer view in this case, because when it's displayed later, the height of the root view will be incorrect, and further result in unexpected animation if it is subsequently resized via the API, browser resize.